### PR TITLE
Refactor controllers routes

### DIFF
--- a/API_contract.md
+++ b/API_contract.md
@@ -6,12 +6,10 @@
 | ---------- | ------ | -------- | ------:|
 | GET | /api/v1/students/:student_id/student_projects?mod=1 | Get all of the project feedback for single student and a single mod | [json](#student-projects-by-mod) |
 | PATCH | /api/v1/students/:student_id/student_projects/:id | Update student's project with personal comments | [json](#students-update-project) |
-| GET | /api/v1/instructors/:instructor_id/instructor_students/:student_id/project_templates?mod=1&project_number=2 | Get a mod project template and rubric categories | [json](#student-project-rubric-categories) |
-| GET | /api/v1/instructors/:instructor_id/instructor_students?mod=1 | Get all of the student names and ids for instructor's current mod | [json](#instructor-module-students) |
+| GET | /api/v1/instructors/:instructor_id/students?mod=1 | Get all of the student names and ids for instructor's current mod | [json](#instructor-module-students) |
 | POST | /api/v1/instructors/:instructor_id/students/search | Instructors search for student's by name  | [json](#instructor-students-search) |
-| POST | /api/v1/student_projects | Instructor create student_project and related project_feedback records | [json](#instructor-create-project-feedback) |
-| POST | /api/v1/users | Registration new user  | [json](#user-registration) |
-| POST | /api/v1/sessions | Login a user | [json](#sessions-create) |
+| GET | /api/v1/instructors/:instructor_id/students/:student_id/project_templates?mod=1&project_number=2 | Get a mod project template and rubric categories | [json](#student-project-rubric-categories) |
+| POST | /api/v1/instructors/:instructor_id/students/:student_id/student_projects | Instructor create student_project and related project_feedback records | [json](#instructor-create-project-feedback) |
 | ERROR | errors | Error handling for requests | [json](#error-handling) |
 
 ## JSON Responses
@@ -202,7 +200,7 @@ Example json response
   ```
 
 ### Instructor Students
-`GET /api/v1/instructor/:instructor_id/instructor_students?mod=x`
+`GET /api/v1/instructor/:instructor_id/students?mod=x`
 
 The request provides the student's (name and id) for a given instructor who teaches a given module
 * __Required__
@@ -212,7 +210,7 @@ The request provides the student's (name and id) for a given instructor who teac
 
  Example json response with projects
 
-  `GET /api/v1/instructor/1/instructor_students?mod=2`
+  `GET /api/v1/instructor/1/students?mod=2`
 
   ```json
   {
@@ -242,7 +240,7 @@ The request provides the student's (name and id) for a given instructor who teac
   ```
 
 ### Student Project Rubric Categories
-`GET /api/v1/instructors/:instructor_id/instructor_students/:student_id/project_templates?mod=1&project_number=2`
+`GET /api/v1/instructors/:instructor_id/students/:student_id/project_templates?mod=1&project_number=2`
 
 The request returns a list of the rubric categories for a given student's mod project.
 * __Required__
@@ -283,7 +281,7 @@ The request returns a list of the rubric categories for a given student's mod pr
   ```
 
 ### Instructor Students Search
-`POST /api/v1/instructor/:instructor_id/instructor_students/search`
+`POST /api/v1/instructor/:instructor_id/students/search`
 
 The request provides all of the *currently enrolled* student's name and id based on a search for either their first name or last name.
 
@@ -291,7 +289,7 @@ The request provides all of the *currently enrolled* student's name and id based
  * Request body must contain a `search_term` key with value(s) `first_name` or `last_name` (or both).
 
  Example json request with body
- `POST /api/v1/instructor/1/instructor_students/search`
+ `POST /api/v1/instructor/1/students/search`
  ```json
   {
     "first_name": "Aid",
@@ -321,13 +319,13 @@ The request provides all of the *currently enrolled* student's name and id based
 ```
 
 ### Instructor Create Project Feedback
-`POST /api/v1/student_projects`
+`POST /api/v1/instructors/:instructor_id/students/:student_id/student_projects`
 
 
 The request creates a student project record and related project feedback records for a valid matching instructor id, student id and project template id.
 * __Required__
 
-  The following fields are required in the post body request. If any required fields are missing or include invalid data an error will be returned (see [error handling](#error-handling)).
+  The following fields are required in the route and post body request. If any required fields are missing or include invalid data an error will be returned (see [error handling](#error-handling)).
   * instructor_id = integer
   * student_id = integer
   * project_template_id = integer
@@ -335,10 +333,9 @@ The request creates a student project record and related project feedback record
   * score = float
 
   Example json request body
+  `/api/v1/instructors/10/students/201/student_projects`
   ```json
   {
-    "instructor_id": 10,
-    "student_id": 201,
     "project_template_id": 16,
     "instructor_comments": "Some real good stuff.",
     "project_feedback": [

--- a/API_contract.md
+++ b/API_contract.md
@@ -8,7 +8,7 @@
 | PATCH | /api/v1/students/:student_id/student_projects/:id | Update student's project with personal comments | [json](#students-update-project) |
 | GET | /api/v1/instructors/:instructor_id/instructor_students/:student_id/project_templates?mod=1&project_number=2 | Get a mod project template and rubric categories | [json](#student-project-rubric-categories) |
 | GET | /api/v1/instructors/:instructor_id/instructor_students?mod=1 | Get all of the student names and ids for instructor's current mod | [json](#instructor-module-students) |
-| POST | /api/v1/instructors/:instructor_id/instructor_students/search | Instructors search for student's by name  | [json](#instructor-students-search) |
+| POST | /api/v1/instructors/:instructor_id/students/search | Instructors search for student's by name  | [json](#instructor-students-search) |
 | POST | /api/v1/student_projects | Instructor create student_project and related project_feedback records | [json](#instructor-create-project-feedback) |
 | POST | /api/v1/users | Registration new user  | [json](#user-registration) |
 | POST | /api/v1/sessions | Login a user | [json](#sessions-create) |
@@ -251,35 +251,36 @@ The request returns a list of the rubric categories for a given student's mod pr
   * mod = integer
   * project_number = integer
 
-  Example json request body
+  Example json response body
+  `GET /api/v1/instructors/116/students/71/project_templates?mod=2&project_number=2`
   ```json
   {
-    "student_id": 71,
-    "project_template_id": 99,
-    "mod": 1,
-    "project_number": 2,
-    "rubric_template": [
-      {
-        "rubric_category_template_id": 1,
-        "rubric_category_name": "ActiveRecord"
-      },
-      {
-        "rubric_category_template_id": 2,
-        "rubric_category_name": "Rails"
-      },
-      {
-        "rubric_category_template_id": 3,
-        "rubric_category_name": "Feature Completeness"
-      },
-      {
-        "rubric_category_template_id": 4,
-        "rubric_category_name": "Testing"
-      }
-    ]
+   "data": {
+      "id": "99",
+      "student_id": 71,
+      "mod": "2",
+      "project_number": "2",
+      "rubric_template": [
+        {
+          "rubric_category_template_id": 1,
+          "rubric_category_name": "ActiveRecord"
+        },
+        {
+          "rubric_category_template_id": 2,
+          "rubric_category_name": "Rails"
+        },
+        {
+          "rubric_category_template_id": 3,
+          "rubric_category_name": "Feature Completeness"
+        },
+        {
+          "rubric_category_template_id": 4,
+          "rubric_category_name": "Testing"
+        }
+      ]
+    }
   }
   ```
-
-The response is the same as the [Student Projects By Mod](#student-projects-by-mod).
 
 ### Instructor Students Search
 `POST /api/v1/instructor/:instructor_id/instructor_students/search`
@@ -288,14 +289,14 @@ The request provides all of the *currently enrolled* student's name and id based
 
 * __Required__
  * Request body must contain a `search_term` key with value(s) `first_name` or `last_name` (or both).
- Example json request with body
- > POST /api/v1/instructor/1/instructor_students/search 
- ```json 
-{
-  "first_name": "Aid",
-  "last_name": "Zie"
-}
 
+ Example json request with body
+ `POST /api/v1/instructor/1/instructor_students/search`
+ ```json
+  {
+    "first_name": "Aid",
+    "last_name": "Zie"
+  }
  ```
 
 

--- a/app/controllers/api/v1/instructor_students_controller.rb
+++ b/app/controllers/api/v1/instructor_students_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::InstructorStudentsController < ApplicationController
     json_response(StudentSerializer.new(instructor.get_students(params[:mod])))
   end
 
-  def show
+  def search
     return json_response({data: "Invalid Query Parameters"}, 400) if (!params.has_key?(:first_name) && !params.has_key?(:last_name) )
     return json_response({data: "Invalid Search Terms"}, 400) if ((!params[:first_name].nil? && params[:first_name].length == 1) ||
                                                                   (!params[:last_name].nil? && params[:last_name].length == 1) )
@@ -14,5 +14,3 @@ class Api::V1::InstructorStudentsController < ApplicationController
     json_response(StudentSerializer.new(students))
   end
 end
-
-

--- a/app/controllers/api/v1/project_templates_controller.rb
+++ b/app/controllers/api/v1/project_templates_controller.rb
@@ -2,8 +2,9 @@ class Api::V1::ProjectTemplatesController < ApplicationController
   before_action :validate_mod, only: :index
   before_action :validate_id, only: :index
   before_action :validate_project, only: :index
+
   def index
-    student = User.find(params[:instructor_student_id])
+    student = User.find(params[:student_id])
     instructor = User.find(params[:instructor_id])
     project_rubric = ProjectRubric.new(params)
     json_response(ProjectRubricSerializer.new(project_rubric))

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,0 @@
-class WelcomeController < ApplicationController
-  def show
-    render json: {data: "ok"}, status: 200
-  end
-end

--- a/app/models/project_template.rb
+++ b/app/models/project_template.rb
@@ -11,5 +11,8 @@ class ProjectTemplate < ApplicationRecord
     where('program = ?', program)
     .where('mod = ?', mod)
     .where('project_number = ?', project_number)
+    .order(created_at: :desc)
+    .limit(1)
+    .first
   end
 end

--- a/app/poros/project_rubric.rb
+++ b/app/poros/project_rubric.rb
@@ -1,18 +1,17 @@
 class ProjectRubric
   attr_reader :id,
               :student_id,
-              :project_template_id,
               :mod,
               :project_number,
               :rubric_template
 
   def initialize(params)
-    @id = project(params)[0].id
-    @student_id = student(params).user.id
-    @project_template_id = project(params)[0].id
-    @mod = student(params).current_mod
-    @project_number = project(params)[0].project_number
-    @rubric_template = print_rubric(RubricTemplate.find(project(params)[0].rubric_template_id).rubric_template_categories)
+    @project = get_project(params)
+    @id = @project.id
+    @student_id = params[:student_id].to_i
+    @mod = params[:mod]
+    @project_number = @project.project_number
+    @rubric_template = print_rubric(RubricTemplate.find(@project.rubric_template_id).rubric_template_categories)
   end
 
 
@@ -23,12 +22,12 @@ class ProjectRubric
       end
     end
 
-    def project(data)
+    def get_project(data)
       ProjectTemplate.get_project(student(data).program, data[:mod], data[:project_number])
     end
 
     def student(data)
-      UserProfile.find_by(user_id: data[:instructor_student_id])
+      UserProfile.find_by(user_id: data[:student_id])
     end
 
 end

--- a/app/poros/project_rubric.rb
+++ b/app/poros/project_rubric.rb
@@ -6,7 +6,7 @@ class ProjectRubric
               :rubric_template
 
   def initialize(params)
-    @project = get_project(params)
+    @project ||= get_project(params)
     @id = @project.id
     @student_id = params[:student_id].to_i
     @mod = params[:mod]

--- a/app/serializers/project_rubric_serializer.rb
+++ b/app/serializers/project_rubric_serializer.rb
@@ -1,7 +1,6 @@
 class ProjectRubricSerializer
   include FastJsonapi::ObjectSerializer
   attributes  :student_id,
-              :project_template_id,
               :mod,
               :project_number,
               :rubric_template

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  root 'welcome#show'
   namespace :api do
     namespace :v1 do
       resources :students, only: [] do
@@ -7,12 +6,11 @@ Rails.application.routes.draw do
       end
 
       resources :instructors, only: [] do
-        post '/instructor_students/search', to: 'instructor_students#show'
-        resources :instructor_students, only: :index, as: 'students'
-          resources :instructor_students, only: [] do
-            resources :project_templates, only: %i[index]
-          end
+        post '/students/search', to: 'instructor_students#search', as: 'students_search'
+        resources :students, only: :index, controller: :instructor_students do
+          resources :project_templates, only: :index
         end
       end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         post '/students/search', to: 'instructor_students#search', as: 'students_search'
         resources :students, only: :index, controller: :instructor_students do
           resources :project_templates, only: :index
+          resources :student_projects, only: :create
         end
       end
     end

--- a/spec/models/project_template_spec.rb
+++ b/spec/models/project_template_spec.rb
@@ -70,20 +70,25 @@ RSpec.describe ProjectTemplate, type: :model do
   describe "class methods" do
     describe "::get_project" do
       it "returns a project that matches a specific program and mod" do
+        student = create(:user)
+        profile = create(:user_profile, current_mod: "2", user_id: student.id)
         rubric_template = create(:rubric_template)
-        project = create(:project_template, program: "FE", mod: "3", project_number: "1", rubric_template_id: rubric_template.id)
-        project_2 = create(:project_template, program: "BE", rubric_template_id: rubric_template.id)
-        project_3 = create(:project_template, program: "BE", rubric_template_id: rubric_template.id)
-        program = "FE"
-        mod = "3"
+        project_1 = create(:project_template, mod: '2', project_number: '1', program: "BE", rubric_template_id: rubric_template.id)
+        project_2 = create(:project_template, mod: '2', project_number: '1', program: "BE", rubric_template_id: rubric_template.id)
+        project_3 = create(:project_template, mod: '3', project_number: '1', program: "BE", rubric_template_id: rubric_template.id)
+        project_4 = create(:project_template, mod: '2', project_number: '1', program: "FE", rubric_template_id: rubric_template.id)
         project_number = "1"
+        mod = "2"
 
-        expect(ProjectTemplate.get_project(program, mod, project_number)[0]).to eq(project)
-        expect(ProjectTemplate.get_project(program, mod, project_number)[0].program).to eq(project.program)
-        expect(ProjectTemplate.get_project(program, mod, project_number)[0].mod).to eq(project.mod)
-        expect(ProjectTemplate.get_project(program, mod, project_number)[0].project_number).to eq(project.project_number)
-        expect(ProjectTemplate.get_project(program, mod, project_number)[0].program).to_not eq(project_2.program)
-        expect(ProjectTemplate.get_project(program, mod, project_number)[0].program).to_not eq(project_3.program)
+        results = ProjectTemplate.get_project(profile.program, mod, project_number)
+
+        expect(results.id).to eq(project_2.id)
+        expect(results.program).to eq(profile.program)
+        expect(results.project_number).to eq(project_number)
+        expect(results.mod).to eq(mod)
+        expect(results.id).to_not eq(project_1.id)
+        expect(results.id).to_not eq(project_3.id)
+        expect(results.id).to_not eq(project_4.id)
       end
     end
   end

--- a/spec/poros/project_rubric_spec.rb
+++ b/spec/poros/project_rubric_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ProjectRubric do
     @project_template_2 = create(:project_template, mod: "2", project_number: "2", rubric_template_id: @mod2_rubric.id)
     @project_2 = create(:student_project, student_id: @student.id, project_template_id: @project_template_2.id)
 
-    data = {instructor_student_id: @student.id, mod: "2", project_number: "2", }
+    data = {student_id: @student.id, mod: "2", project_number: "2", }
     @project_rubric = ProjectRubric.new(data)
   end
   it "exists" do

--- a/spec/requests/api/v1/instructors/instructor_project_rubric_spec.rb
+++ b/spec/requests/api/v1/instructors/instructor_project_rubric_spec.rb
@@ -32,14 +32,15 @@ RSpec.describe 'Instructor Project Rubric Request' do
   end
   describe "happy path" do
     it "returns rubric categories for the given student, mod, and project number" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{@student.id}/project_templates?mod=2&project_number=2"
-      expect(response).to be_successful
+      get "/api/v1/instructors/#{@instructor.id}/students/#{@student.id}/project_templates?mod=2&project_number=2"
+
       project_rubric = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(response).to be_successful
       expect(project_rubric).to have_key(:data)
       expect(project_rubric[:data]).to have_key(:id)
       expect(project_rubric[:data]).to have_key(:type)
       expect(project_rubric[:data][:attributes]).to have_key(:student_id)
-      expect(project_rubric[:data][:attributes]).to have_key(:project_template_id)
       expect(project_rubric[:data][:attributes]).to have_key(:mod)
       expect(project_rubric[:data][:attributes]).to have_key(:project_number)
       expect(project_rubric[:data][:attributes]).to have_key(:rubric_template)
@@ -58,7 +59,7 @@ RSpec.describe 'Instructor Project Rubric Request' do
   end
   describe "sad path" do
     it "needs project_number query parameter" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{@student.id}/project_templates?mod=2"
+      get "/api/v1/instructors/#{@instructor.id}/students/#{@student.id}/project_templates?mod=2"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to have_key(:message)
       expect(project_rubric).to have_key(:error)
@@ -67,7 +68,7 @@ RSpec.describe 'Instructor Project Rubric Request' do
       expect(response.status).to eq(400)
     end
     it "needs mod query parameter" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{@student.id}/project_templates?project_number=2"
+      get "/api/v1/instructors/#{@instructor.id}/students/#{@student.id}/project_templates?project_number=2"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to have_key(:message)
       expect(project_rubric).to have_key(:error)
@@ -76,14 +77,14 @@ RSpec.describe 'Instructor Project Rubric Request' do
       expect(response.status).to eq(400)
     end
     it "project number parameter has to be a number in a string between 1 and 4" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{@student.id}/project_templates?mod=2&project_number=-1"
+      get "/api/v1/instructors/#{@instructor.id}/students/#{@student.id}/project_templates?mod=2&project_number=-1"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to have_key(:message)
       expect(project_rubric).to have_key(:error)
       expect(project_rubric[:message]).to eq("your request cannot be completed")
       expect(project_rubric[:error]).to eq("Project_number parameter is missing or invalid")
       expect(response.status).to eq(400)
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{@student.id}/project_templates?mod=2&project_number=5"
+      get "/api/v1/instructors/#{@instructor.id}/students/#{@student.id}/project_templates?mod=2&project_number=5"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to have_key(:message)
       expect(project_rubric).to have_key(:error)
@@ -92,14 +93,14 @@ RSpec.describe 'Instructor Project Rubric Request' do
       expect(response.status).to eq(400)
     end
     it "mod parameter has to be a number in a string between 1 and 4" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{@student.id}/project_templates?mod=-1&project_number=2"
+      get "/api/v1/instructors/#{@instructor.id}/students/#{@student.id}/project_templates?mod=-1&project_number=2"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to have_key(:message)
       expect(project_rubric).to have_key(:error)
       expect(project_rubric[:message]).to eq("your request cannot be completed")
       expect(project_rubric[:error]).to eq("Mod parameter is missing or invalid")
       expect(response.status).to eq(400)
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{@student.id}/project_templates?mod=5&project_number=2"
+      get "/api/v1/instructors/#{@instructor.id}/students/#{@student.id}/project_templates?mod=5&project_number=2"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to have_key(:message)
       expect(project_rubric).to have_key(:error)
@@ -109,13 +110,13 @@ RSpec.describe 'Instructor Project Rubric Request' do
     end
     it "instructor and student id must exists in our database" do
       id = 999999
-      get "/api/v1/instructors/#{id}/instructor_students/#{@student.id}/project_templates?mod=2&project_number=2"
+      get "/api/v1/instructors/#{id}/students/#{@student.id}/project_templates?mod=2&project_number=2"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to_not have_key(:message)
       expect(project_rubric).to have_key(:error)
       expect(project_rubric[:error]).to eq("Couldn't find User with 'id'=#{id}")
       expect(response.status).to eq(404)
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students/#{id}/project_templates?mod=2&project_number=2"
+      get "/api/v1/instructors/#{@instructor.id}/students/#{id}/project_templates?mod=2&project_number=2"
       project_rubric = JSON.parse(response.body, symbolize_names: true)
       expect(project_rubric).to_not have_key(:message)
       expect(project_rubric).to have_key(:error)

--- a/spec/requests/api/v1/instructors/instructor_student_search_spec.rb
+++ b/spec/requests/api/v1/instructors/instructor_student_search_spec.rb
@@ -13,14 +13,14 @@ describe 'Instructor Students request' do
     instructor_profile = create(:user_profile, user_id: @instructor.id, current_mod: "2")
   end
 
-  let!(:body) { { 
+  let!(:body) { {
       first_name: "#{@student_1_profile.first_name}"
     }}
 
-    
+
   describe 'happy path' do
     it "returns one or more students matching the first name request" do
-      post api_v1_instructor_instructor_students_search_path(@instructor.id), headers: headers, params: body, as: :json
+      post api_v1_instructor_students_search_path(@instructor.id), headers: headers, params: body, as: :json
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data].class).to eq Array
       expect(json[:data].first.keys).to eq [:id, :type, :attributes]
@@ -33,7 +33,7 @@ describe 'Instructor Students request' do
       }}
 
       it "returns one or more students matching the partial first name request" do
-        post api_v1_instructor_instructor_students_search_path(@instructor.id), headers: headers, params: partial_body, as: :json
+        post api_v1_instructor_students_search_path(@instructor.id), headers: headers, params: partial_body, as: :json
         json = JSON.parse(response.body, symbolize_names: true)
         expect(json[:data].class).to eq Array
         expect(json[:data].first.keys).to eq [:id, :type, :attributes]
@@ -44,9 +44,9 @@ describe 'Instructor Students request' do
       let!(:partial_last_body) { {
           last_name: "Aar"
         }}
-  
+
         it "returns one or more students matching the partial last name request" do
-          post api_v1_instructor_instructor_students_search_path(@instructor.id), headers: headers, params: partial_last_body, as: :json
+          post api_v1_instructor_students_search_path(@instructor.id), headers: headers, params: partial_last_body, as: :json
           json = JSON.parse(response.body, symbolize_names: true)
           expect(json[:data].class).to eq Array
           expect(json[:data].first.keys).to eq [:id, :type, :attributes]
@@ -59,7 +59,7 @@ describe 'Instructor Students request' do
       }}
 
     it "returns one or more students matching the last name request" do
-      post api_v1_instructor_instructor_students_search_path(@instructor.id), headers: headers, params: last_name_body, as: :json
+      post api_v1_instructor_students_search_path(@instructor.id), headers: headers, params: last_name_body, as: :json
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data].class).to eq Array
       expect(json[:data].first.keys).to eq [:id, :type, :attributes]
@@ -72,7 +72,7 @@ describe 'Instructor Students request' do
       }}
 
     it "returns one or more students matching the full name request" do
-      post api_v1_instructor_instructor_students_search_path(@instructor.id), headers: headers, params: full_name_body, as: :json
+      post api_v1_instructor_students_search_path(@instructor.id), headers: headers, params: full_name_body, as: :json
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data].class).to eq Array
       expect(json[:data].first.keys).to eq [:id, :type, :attributes]
@@ -88,16 +88,16 @@ describe 'Instructor Students request' do
       }}
 
       let!(:edge_path_body) { {
-        
+
       }}
     it "needs 2 or more characters to search" do
-      post api_v1_instructor_instructor_students_search_path(@instructor.id), headers: headers, params: sad_path_body, as: :json
+      post api_v1_instructor_students_search_path(@instructor.id), headers: headers, params: sad_path_body, as: :json
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data]).to eq "Invalid Search Terms"
     end
 
     it "needs required parameters" do
-      post api_v1_instructor_instructor_students_search_path(@instructor.id), headers: headers, params: edge_path_body, as: :json
+      post api_v1_instructor_students_search_path(@instructor.id), headers: headers, params: edge_path_body, as: :json
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data]).to eq "Invalid Query Parameters"
     end

--- a/spec/requests/api/v1/instructors/instructors_students_request_spec.rb
+++ b/spec/requests/api/v1/instructors/instructors_students_request_spec.rb
@@ -17,7 +17,7 @@ describe 'Instructor Students request' do
   end
   describe 'happy path' do
     it "returns information about the students under an instructor" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students?mod=2"
+      get "/api/v1/instructors/#{@instructor.id}/students?mod=2"
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data].class).to eq Array
       expect(json[:data].first[:type]).to eq "student"
@@ -25,7 +25,7 @@ describe 'Instructor Students request' do
     end
 
     it "returns only the students in the specified mod" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students?mod=2"
+      get "/api/v1/instructors/#{@instructor.id}/students?mod=2"
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data].none?{ |student| student[:attributes][:first_name] == @student_3.user_profile.first_name }).to eq true
     end
@@ -35,13 +35,13 @@ describe 'Instructor Students request' do
 
   describe 'sad path' do
     it "should return bad data for missing query parameters" do
-      get "/api/v1/instructors/#{@instructor.id}/instructor_students"
+      get "/api/v1/instructors/#{@instructor.id}/students"
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:data]).to eq "Invalid Query Parameters"
     end
 
     it "should be given a correct instructor id" do
-      get "/api/v1/instructors/99999/instructor_students?mod=2"
+      get "/api/v1/instructors/99999/students?mod=2"
       json = JSON.parse(response.body, symbolize_names: true)
       expect(json[:error]).to eq "Couldn't find User with 'id'=99999"
     end


### PR DESCRIPTION
### Update / Remove
* API contract and routes to make more RESTful
* Specs and controllers accordingly based on new routes
* ProjectRubric poro refactored when project template is queried from model in poro and memoized data
### Why?
* Routes that used instructor_students as resource were not restful (my fault). Instead should be instructors then nested students to follow convention
* Speed up test suite and project rubric template endpoint to reduce number of times queries to models had to be made.

Close #76 
