### PR TITLE
Turn student comments to array

### DIFF
--- a/API_contract.md
+++ b/API_contract.md
@@ -43,7 +43,7 @@ The request provides the projects for a valid matching student id and mod (sent 
             "is_final_project": false,
             "average_score": "2.75",
             "instructor_comments": "Some real good stuff.",
-            "student_comments": "My personal notes.",
+            "student_comments": ["My personal notes."],
             "project_feedback": [
               {
                 "id": "1",
@@ -136,14 +136,14 @@ The request updates the student project record with personal student comments th
 
   The following field is required in the post body request. If any required fields are missing or include invalid data an error will be returned (see [error handling](#error-handling)).
 
-  * student_comments = string
+  * student_comments = Array or null
 
 __** If existing student comments are removed please send a nil value.__
 
   Example json request body
   ```json
   {
-    "student_comments": "Me-Mow ate my homework. I swear!"
+    "student_comments": ["Me-Mow ate my homework. I swear!", "Seriously!"]
   }
   ```
 
@@ -165,7 +165,9 @@ Example json response
             "is_final_project": false,
             "average_score": "2.75",
             "instructor_comments": "Some real good stuff.",
-            "student_comments": "Me-Mow ate my homework. I swear!",
+            "student_comments": [
+              "Me-Mow ate my homework. I swear!", "Seriously!"
+            ],
             "project_feedback": [
               {
                 "id": "1",
@@ -205,8 +207,8 @@ Example json response
 The request provides the student's (name and id) for a given instructor who teaches a given module
 * __Required__
  * Mod query parameter must be included and have an integer value between 0-4. If the mod query parameter is missing, or is an invalid value an error is sent (see [error handling](#error-handling)).
- * Data is returned in ascending order by user_id.
- * Students are only returned when they lie within the given module request
+ * Data is returned in ascending order by first_name and then last_name of the student.
+ * Students are only returned when they lie within the given module request and are associated to that instructor.
 
  Example json response with projects
 

--- a/app/controllers/api/v1/student_projects_controller.rb
+++ b/app/controllers/api/v1/student_projects_controller.rb
@@ -10,8 +10,6 @@ class Api::V1::StudentProjectsController < ApplicationController
   def update
     return render_error("Required parameter missing") if missing_params(required_update)
     project = StudentProject.find_by!(id: params[:id], student_id: params[:student_id])
-    # require "pry"; binding.pry
-    # student_comments = {student_comments: params[:student_comments].join("/2C/")}
     project.update(student_comments)
     params[:mod] = project.project_template.mod
     projects = Projects.new(params)

--- a/app/controllers/api/v1/student_projects_controller.rb
+++ b/app/controllers/api/v1/student_projects_controller.rb
@@ -10,7 +10,9 @@ class Api::V1::StudentProjectsController < ApplicationController
   def update
     return render_error("Required parameter missing") if missing_params(required_update)
     project = StudentProject.find_by!(id: params[:id], student_id: params[:student_id])
-    project.update(student_comments_params)
+    # require "pry"; binding.pry
+    # student_comments = {student_comments: params[:student_comments].join("/2C/")}
+    project.update(student_comments)
     params[:mod] = project.project_template.mod
     projects = Projects.new(params)
     render_success(ProjectsSerializer.new(projects))
@@ -26,7 +28,13 @@ class Api::V1::StudentProjectsController < ApplicationController
     [:student_id, :id, :student_comments]
   end
 
-  def student_comments_params
-    params.permit(:student_comments)
+  def student_comments
+    if params[:student_comments].nil?
+      {student_comments: params[:student_comments]}
+    elsif params[:student_comments].count > 1
+      {student_comments: params[:student_comments].join("/2C/")}
+    else
+      {student_comments: params[:student_comments][0]}
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,9 +28,6 @@ class User < ApplicationRecord
     .joins(:user_profile)
     .where('user_profiles.current_mod = ?', mod_num)
     .order('user_profiles.first_name, user_profiles.last_name')
-    # students.map do |student|
-    #   student.user_profile if student.user_profile.current_mod == mod_num
-    # end.compact
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,10 +23,15 @@ class User < ApplicationRecord
   has_one :user_profile
 
   def get_students(mod_num)
-    students.map do |student|
-      student.user_profile if student.user_profile.current_mod == mod_num
-    end.compact
+    students
+    .select('user_profiles.*')
+    .joins(:user_profile)
+    .where('user_profiles.current_mod = ?', mod_num)
+    .order('user_profiles.first_name, user_profiles.last_name')
+    # students.map do |student|
+    #   student.user_profile if student.user_profile.current_mod == mod_num
+    # end.compact
   end
 
- 
+
 end

--- a/app/poros/student_projects.rb
+++ b/app/poros/student_projects.rb
@@ -35,6 +35,6 @@ class StudentProjects
   end
 
   def format_comments(data)
-    [data.split("/2C/")].to_a.flatten if !data.nil?
+    data.split("/2C/").to_a if !data.nil?
   end
 end

--- a/app/poros/student_projects.rb
+++ b/app/poros/student_projects.rb
@@ -19,7 +19,7 @@ class StudentProjects
     @is_final_project = data[:is_final_project]
     @average_score = data.average_feedback_score
     @instructor_comments = data[:instructor_comments]
-    @student_comments = data[:student_comments]
+    @student_comments = format_comments(data[:student_comments])
     @project_feedback = get_project_feedback(data)
   end
 
@@ -32,5 +32,9 @@ class StudentProjects
         comment: feedback.comment
       }
     end
+  end
+
+  def format_comments(data)
+    [data.split("/2C/")].to_a.flatten if !data.nil?
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,18 +75,27 @@ RSpec.describe User, type: :model do
   describe 'instance methods' do
     it "get_students" do
       instructor = User.create!(email: 'haegonorious@email.com', password: 'password', role: :instructor)
-      student = User.create!(email: 'bazzinni@email.com', password: 'password', role: :student)
-  
-      instructor_student = create(:instructor_student, instructor_id: instructor.id, student_id: student.id)
-      student_profile = create(:user_profile, user_id: student.id, current_mod: "2", starting_cohort: "2010", current_cohort: "2010", status: 0)
+      student_1 = User.create!(email: 'bazzinni@email.com', password: 'password', role: :student)
+      students = create_list(:user, 5, role: 0)
+
+      instructor_student = create(:instructor_student, instructor_id: instructor.id, student_id: student_1.id)
+      student_profile = create(:user_profile, user_id: student_1.id, current_mod: "2", starting_cohort: "2010", current_cohort: "2010", status: 0, first_name: 'Bazzinni')
+      n = 0
+      student_profiles = students[0..3].each do |student|
+        n = n +=1
+        create(:user_profile, user_id: student.id, current_mod: "2", starting_cohort: "2010", current_cohort: "2010", status: 0, first_name: "Name #{n}")
+        create(:instructor_student, instructor_id: instructor.id, student_id: student.id)
+      end
+      non_mod2_student = create(:user_profile, user_id: students.last.id, current_mod: "3", starting_cohort: "2010", current_cohort: "2010", status: 0)
       instructor_profile = create(:user_profile, user_id: instructor.id, current_mod: "2")
-  
-      expect(instructor.get_students("2").class).to eq Array
-      expect(instructor.get_students("2").first).to eq student_profile
-      expect(instructor.get_students("3")).to eq ([]) 
+
+      expect(instructor.get_students("2").count).to eq(5)
+      expect(instructor.get_students("2").first.first_name).to eq student_profile.first_name
+      expect(instructor.get_students("2").last.first_name).to eq students.fourth.user_profile.first_name
+      expect(instructor.get_students("3")).to eq ([])
 
     end
 
-    
+
   end
 end

--- a/spec/poros/student_projects_spec.rb
+++ b/spec/poros/student_projects_spec.rb
@@ -28,8 +28,8 @@ describe StudentProjects, type: :request do
       expect(student_project.average_score).to eq(0.35e1)
       expect(student_project.instructor_comments).to be_a(String)
       expect(student_project.instructor_comments).to eq(@project_2.instructor_comments)
-      expect(student_project.student_comments).to be_a(String)
-      expect(student_project.student_comments).to eq(@project_2.student_comments)
+      expect(student_project.student_comments).to be_an(Array)
+      expect(student_project.student_comments).to eq([@project_2.student_comments])
       expect(student_project.project_feedback).to be_an(Array)
       expect(student_project.project_feedback.count).to eq(5)
 

--- a/spec/requests/api/v1/instructors/instructors_students_request_spec.rb
+++ b/spec/requests/api/v1/instructors/instructors_students_request_spec.rb
@@ -18,7 +18,9 @@ describe 'Instructor Students request' do
   describe 'happy path' do
     it "returns information about the students under an instructor" do
       get "/api/v1/instructors/#{@instructor.id}/students?mod=2"
+
       json = JSON.parse(response.body, symbolize_names: true)
+
       expect(json[:data].class).to eq Array
       expect(json[:data].first[:type]).to eq "student"
       expect(json[:data].first[:attributes].keys).to eq %i(user_id first_name last_name current_cohort)
@@ -26,7 +28,9 @@ describe 'Instructor Students request' do
 
     it "returns only the students in the specified mod" do
       get "/api/v1/instructors/#{@instructor.id}/students?mod=2"
+
       json = JSON.parse(response.body, symbolize_names: true)
+
       expect(json[:data].none?{ |student| student[:attributes][:first_name] == @student_3.user_profile.first_name }).to eq true
     end
 

--- a/spec/requests/api/v1/students/student_projects_request_spec.rb
+++ b/spec/requests/api/v1/students/student_projects_request_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe 'Student projects request', type: :request do
         expect(project[:is_final_project]).to be_a(FalseClass).or be_a(TrueClass)
         check_hash_structure(project, :average_score, String)
         check_hash_structure(project, :instructor_comments, String)
-        check_hash_structure(project, :student_comments, String)
+        check_hash_structure(project, :student_comments, Array)
+        expect(project[:student_comments]).to eq([@project_2.student_comments.split("/2C/")].to_a.flatten)
       end
 
       it "the projects response for a valid request includes project feedback data" do

--- a/spec/requests/api/v1/students/student_projects_request_spec.rb
+++ b/spec/requests/api/v1/students/student_projects_request_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Student projects request', type: :request do
         check_hash_structure(project, :average_score, String)
         check_hash_structure(project, :instructor_comments, String)
         check_hash_structure(project, :student_comments, Array)
-        expect(project[:student_comments]).to eq([@project_2.student_comments.split("/2C/")].to_a.flatten)
+        expect(project[:student_comments]).to eq(@project_2.student_comments.split("/2C/").to_a)
       end
 
       it "the projects response for a valid request includes project feedback data" do

--- a/spec/requests/api/v1/students/update_student_comments_spec.rb
+++ b/spec/requests/api/v1/students/update_student_comments_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Student comments request', type: :request do
         expect(@project_2.student_comments).to_not be_nil
         previous_comment = @project_2.student_comments
 
-        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!", "I cannot believe he did!", "He has been \npunished!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
         patch "/api/v1/students/#{@student.id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json
 
@@ -59,7 +59,7 @@ RSpec.describe 'Student comments request', type: :request do
 
         @project_2.reload
         expect(@project_2.student_comments).to_not eq(previous_comment)
-        expect([@project_2.student_comments]).to eq(params[:student_comments])
+        expect(@project_2.student_comments.split("/2C/").to_a).to eq(params[:student_comments])
         expect(response).to be_successful
       end
 

--- a/spec/requests/api/v1/students/update_student_comments_spec.rb
+++ b/spec/requests/api/v1/students/update_student_comments_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe 'Student comments request', type: :request do
         @project_2.update(student_comments: nil)
         expect(@project_2.student_comments).to be_nil
 
-        params = {student_comments: "Me-Mow ate my homework. I swear!"}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!", "I am adding another note"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
         patch "/api/v1/students/#{@student.id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json
 
         json = JSON.parse(response.body, symbolize_names:true)
 
         @project_2.reload
-        expect(@project_2.student_comments).to eq(params[:student_comments])
+        expect(@project_2.student_comments.split("/2C/")).to eq(params[:student_comments])
         expect(response).to be_successful
         expect(json).to be_a(Hash)
         expect(json[:data]).to be_a(Hash)
@@ -35,7 +35,7 @@ RSpec.describe 'Student comments request', type: :request do
         expect(@project_2.student_comments).to_not be_nil
         previous_comment = @project_2.student_comments
 
-        params = {student_comments: "Me-Mow ate my homework. I swear!"}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
         patch "/api/v1/students/#{@student.id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json
 
@@ -43,11 +43,27 @@ RSpec.describe 'Student comments request', type: :request do
 
         @project_2.reload
         expect(@project_2.student_comments).to_not eq(previous_comment)
-        expect(@project_2.student_comments).to eq(params[:student_comments])
+        expect([@project_2.student_comments]).to eq(params[:student_comments])
         expect(response).to be_successful
       end
 
-      it "updates the student comments and removes existing comment if value request is an empty string" do
+      it "updates the student comments with multiple comments and accepts new line" do
+        expect(@project_2.student_comments).to_not be_nil
+        previous_comment = @project_2.student_comments
+
+        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
+        headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+        patch "/api/v1/students/#{@student.id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json
+
+        json = JSON.parse(response.body, symbolize_names:true)
+
+        @project_2.reload
+        expect(@project_2.student_comments).to_not eq(previous_comment)
+        expect([@project_2.student_comments]).to eq(params[:student_comments])
+        expect(response).to be_successful
+      end
+
+      it "updates the student comments and removes existing comment if value request is nil" do
         expect(@project_2.student_comments).to_not be_nil
         previous_comment = @project_2.student_comments
 
@@ -67,7 +83,7 @@ RSpec.describe 'Student comments request', type: :request do
     describe 'edge case' do
       it "returns an error when the student id is invalid" do
         id = 201
-        params = {student_comments: "Me-Mow ate my homework. I swear!"}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
 
         patch "/api/v1/students/#{id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json
@@ -82,7 +98,7 @@ RSpec.describe 'Student comments request', type: :request do
 
       it "returns an error when the student id is not an integer" do
         id = "puppies"
-        params = {student_comments: "Me-Mow ate my homework. I swear!"}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
 
         patch "/api/v1/students/#{id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json
@@ -97,7 +113,7 @@ RSpec.describe 'Student comments request', type: :request do
 
       it "returns an error when the project id is invalid" do
         id = 201
-        params = {student_comments: "Me-Mow ate my homework. I swear!"}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
 
         patch "/api/v1/students/#{@student.id}/student_projects/#{id}", headers: headers, params: params.to_json
@@ -112,7 +128,7 @@ RSpec.describe 'Student comments request', type: :request do
 
       it "returns an error when the project id is not an integer" do
         id = "puppies"
-        params = {student_comments: "Me-Mow ate my homework. I swear!"}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
 
         patch "/api/v1/students/#{@student.id}/student_projects/#{id}", headers: headers, params: params.to_json
@@ -130,7 +146,7 @@ RSpec.describe 'Student comments request', type: :request do
         expect(student_2.student_projects.empty?).to eq(true)
         expect(@project_2.student_id).to_not eq(student_2.id)
 
-        params = {student_comments: "Me-Mow ate my homework. I swear!"}
+        params = {student_comments: ["Me-Mow ate my homework. I swear!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
 
         patch "/api/v1/students/#{student_2.id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json
@@ -144,7 +160,7 @@ RSpec.describe 'Student comments request', type: :request do
       end
 
       it "returns an error when the student_comments attribute is missing" do
-        params = {nope: "Me-Mow ate my homework. I swear!"}
+        params = {nope: ["Me-Mow ate my homework. I swear!"]}
         headers = {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
 
         patch "/api/v1/students/#{@student.id}/student_projects/#{@project_2.id}", headers: headers, params: params.to_json


### PR DESCRIPTION
### Update / Remove
* get_students method on User to use AR and order results by first name then last name
* allow student comments to be received and sent out in an array format
  * array is joined on BE before saving in DB using "/2C/" as our special character to denote each element
* API contract to reflect the changes above
### Why?
* User empathy for instructor, better to display list in alphabetical order
* UX preference by FE to allow user to have list of comments rather than just a single string

Close #80 
close #81 
